### PR TITLE
Fix for fields always being visible inside Matrix blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Usage
 When creating a new Preparse field, you can add the Twig that you want to run to the fields settings. When the entry is 
 saved, the element that is saved will be passed to the code, with the same name as it's element type. So, if the field 
 is attached to an entry, `entry` will be available. If it is attached to a category, user or global set, `category`, `user`
-and `globalset` will be available.
+and `globalset` will be available.  
+
+**Usage in Matrix**  
+When a Preparse field is added to a Matrix block, that block will be available to the Twig code as the variable `matrixblock`. The element (entry, category, global set etc) the Matrix field belongs to will be available under `matrixblock.owner`.  
   
 ### Examples  
   
@@ -70,7 +73,6 @@ advanced stuff and/or want to keep your fields Twig in version control:
 	
 Make sure that you always write solid Twig, taking into account that fields may not be populated yet. If an error occurs
 in your Twig, the element will not be saved. 
- 
  
 Cache gotchas
 ---

--- a/preparsefield/templates/field.html
+++ b/preparsefield/templates/field.html
@@ -1,6 +1,6 @@
 {% if not settings.showField %}
 <style>
-  #fields-{{ name }}-field {
+  #{{ id }}-field {
     display: none;
   }
 </style>


### PR DESCRIPTION
Fixes an issue where Preparse fields are always visible inside Matrix blocks. Also adds a note on Matrix usage to README.