### PR TITLE
Set generateTransformsBeforePageLoad = true

### DIFF
--- a/preparsefield/fieldtypes/PreparseField_PreparseFieldType.php
+++ b/preparsefield/fieldtypes/PreparseField_PreparseFieldType.php
@@ -18,6 +18,11 @@ class PreparseField_PreparseFieldType extends BaseFieldType
      */
     public function onAfterElementSave()
     {
+        // Set generateTransformsBeforePageLoad = true
+        $configService = craft()->config;
+        $generateTransformsBeforePageLoad = $configService->get('generateTransformsBeforePageLoad');
+        $configService->set('generateTransformsBeforePageLoad', true);
+        
         $fieldHandle = $this->model->handle;
         $fieldTwig = $this->getSettings()->fieldTwig;
         $elementType = $this->element->getElementType();
@@ -37,6 +42,9 @@ class PreparseField_PreparseFieldType extends BaseFieldType
                   LogLevel::Error);
             }
         }
+        
+        // Set generateTransformsBeforePageLoad back to whatever it was
+        $configService->set('generateTransformsBeforePageLoad', $generateTransformsBeforePageLoad);
     }
 
     /**


### PR DESCRIPTION
Sets the generateTransformsBeforePageLoad config setting to 'true' for the duration of onAfterElementSave(), in case the preparse template has any image transform URLs (would not want to chance getting the transform generation URL cached).