### PR TITLE
Add setting to allow visible preparse field contents to be highlighted

### DIFF
--- a/preparsefield/fieldtypes/PreparseField_PreparseFieldType.php
+++ b/preparsefield/fieldtypes/PreparseField_PreparseFieldType.php
@@ -59,6 +59,7 @@ class PreparseField_PreparseFieldType extends BaseFieldType implements IPreviewa
           'decimals' => array(AttributeType::Number, 'default' => 0),
           'parseBeforeSave' => array(AttributeType::Bool, 'default' => false),
           'parseOnMove' => array(AttributeType::Bool, 'default' => false),
+          'allowSelect' => array(AttributeType::Bool, 'default' => false),
         );
     }
 

--- a/preparsefield/templates/field.html
+++ b/preparsefield/templates/field.html
@@ -13,5 +13,6 @@
   id: name,
   name: name,
   value: value,
-  disabled: true
+  disabled: not settings.allowSelect,
+  readonly: settings.allowSelect
 }) }}

--- a/preparsefield/templates/settings.html
+++ b/preparsefield/templates/settings.html
@@ -65,3 +65,13 @@
   onLabel: "Yes"|t,
   offLabel: "no"|t
 }) }}
+
+{{ forms.lightswitchField({
+  label: "Allow text highlighting"|t,
+  instructions: "If you turn this on and the field is visible, the output of the field will be selectable by the user."|t,
+  id: 'allowSelect',
+  name: 'allowSelect',
+  on: settings.allowSelect,
+  onLabel: "Yes"|t,
+  offLabel: "no"|t
+}) }}


### PR DESCRIPTION
Add setting to allow visible preparse field contents to be highlighted by the user, toggles input from disabled to readonly.