### PR TITLE
When number option selected, treat just like a number fieldtype.

### DIFF
--- a/preparsefield/fieldtypes/PreparseField_PreparseFieldType.php
+++ b/preparsefield/fieldtypes/PreparseField_PreparseFieldType.php
@@ -106,4 +106,25 @@ class PreparseField_PreparseFieldType extends BaseFieldType implements IPreviewa
 
         return array(AttributeType::String, 'column' => $settings->columnType);
     }
+
+    /**
+	 * Preps POST value
+	 *
+	 * @param mixed $data
+	 *
+	 * @return mixed
+	 */
+    public function prepValueFromPost($data)
+    {
+        $settings = $this->getSettings();
+
+        if ($settings->columnType === 'number') {
+            $numberFieldType = new NumberFieldType();
+
+            return $numberFieldType->prepValueFromPost($data);
+        }
+
+        return $data;
+    }
+
 }


### PR DESCRIPTION
Just another check to make sure numbers get saved just like as if it were a core "Number" field type.