### PR TITLE
Fix warning when changing column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Preparse Field Changelog
 
+## 1.0.6 - 2019-03-21
+### Fixed
+- Fixed a bug where warnings weren’t showing up when editing an existing preparse field’s column type.
+
 ## 1.0.5.1 - 2019-02-27
-### Added
+### Fixed
 - Fixed an error that occurred when updating to preparse 1.0.5 on Craft 3.0.x
 
 ## 1.0.5 - 2019-02-27

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "aelvan/preparse-field",
     "description": "A fieldtype that parses Twig when an element is saved, and saves the result as plain text.",
     "type": "craft-plugin",
-    "version": "v1.0.5.1",
+    "version": "v1.0.6",
     "keywords": [
         "craft",
         "cms",

--- a/src/fields/PreparseFieldType.php
+++ b/src/fields/PreparseFieldType.php
@@ -57,7 +57,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface
 
     // Public Methods
     // =========================================================================
-    
+
     public function rules()
     {
         $rules = parent::rules();
@@ -92,7 +92,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface
         if ($this->columnType === Schema::TYPE_DECIMAL) {
             return Db::getNumericalColumnType(null, null, $this->decimals);
         }
-        
+
         return $this->columnType;
     }
 
@@ -110,7 +110,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface
             Schema::TYPE_DECIMAL => Craft::t('preparse-field', 'Number (decimal)'),
             Schema::TYPE_FLOAT => Craft::t('preparse-field', 'Number (float)'),
         ];
-        
+
         $displayTypes = [
             'hidden' => 'Hidden',
             'textinput' => 'Text input',
@@ -124,7 +124,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface
                 'field' => $this,
                 'columns' => $columns,
                 'displayTypes' => $displayTypes,
-                'existing' => !empty($this->model->id),
+                'existing' => $this->id !== null,
             ]
         );
     }
@@ -140,7 +140,7 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface
         // Get our id and namespace
         $id = Craft::$app->getView()->formatInputId($this->handle);
         $namespacedId = Craft::$app->getView()->namespaceInputId($id);
-        
+
         // Render the input template
         return Craft::$app->getView()->renderTemplate(
             'preparse-field/_components/fields/_input',


### PR DESCRIPTION
This will probably also fix #49, even though I don’t understand why `empty()` throws an error in @matthillco dev environment.