### PR TITLE
Fixed Craft 3.2 compatibility

### DIFF
--- a/src/PreparseField.php
+++ b/src/PreparseField.php
@@ -79,8 +79,8 @@ class PreparseField extends Plugin
                 $element = $event->element;
                 $key = $element->id . '__' . $element->siteId;
 
-                if (!\in_array($key, $this->preparsedElements['onBeforeSave'], true)) {
-                    $this->preparsedElements['onBeforeSave'][] = $key;
+                if (!isset($this->preparsedElements['onBeforeSave'][$key])) {
+                    $this->preparsedElements['onBeforeSave'][$key] = true;
 
                     $content = self::$plugin->preparseFieldService->getPreparseFieldsContent($element, 'onBeforeSave');
 
@@ -88,6 +88,8 @@ class PreparseField extends Plugin
                         $this->resetUploads();
                         $element->setFieldValues($content);
                     }
+
+                    unset($this->preparsedElements['onBeforeSave'][$key]);
                 }
             }
         );
@@ -99,8 +101,8 @@ class PreparseField extends Plugin
                 $element = $event->element;
                 $key = $element->id . '__' . $element->siteId;
 
-                if (!\in_array($key, $this->preparsedElements['onSave'], true)) {
-                    $this->preparsedElements['onSave'][] = $key;
+                if (!isset($this->preparsedElements['onSave'][$key])) {
+                    $this->preparsedElements['onSave'][$key] = true;
 
                     $content = self::$plugin->preparseFieldService->getPreparseFieldsContent($element, 'onSave');
                     
@@ -119,6 +121,8 @@ class PreparseField extends Plugin
                             Craft::error('Couldn’t save element with id “' . $element->id . '”', __METHOD__);
                         }
                     }
+
+                    unset($this->preparsedElements['onSave'][$key]);
                 }
             }
         );
@@ -130,8 +134,8 @@ class PreparseField extends Plugin
                 $element = $event->element;
                 $key = $element->id . '__' . $element->siteId;
 
-                if (self::$plugin->preparseFieldService->shouldParseElementOnMove($element) && !\in_array($key, $this->preparsedElements['onMoveElement'], true)) {
-                    $this->preparsedElements['onMoveElement'][] = $key;
+                if (self::$plugin->preparseFieldService->shouldParseElementOnMove($element) && !isset($this->preparsedElements['onMoveElement'][$key])) {
+                    $this->preparsedElements['onMoveElement'][$key] = true;
 
                     if ($element instanceof Asset) {
                         $element->setScenario(Element::SCENARIO_DEFAULT);
@@ -143,6 +147,8 @@ class PreparseField extends Plugin
                     if (!$success) {
                         Craft::error('Couldn’t move element with id “' . $element->id . '”', __METHOD__);
                     }
+
+                    unset($this->preparsedElements['onMoveElement'][$key]);
                 }
             }
         );


### PR DESCRIPTION
Someone came across an issue where Preparse wasn’t saving the correct asset URLs when saving an entry for the first time in Craft 3.2.

For a little context, in Craft 3.2 when you create a new entry, a new entry draft is immediately created, and then Craft starts autosaving it as you make changes to it. Throughout that time, any assets you upload to an Assets field with a dynamic subpath will be placed in a temp folder.

When you click “Save entry”, Craft will save the draft one last time to make sure it has all the latest form data ([EntryRevisionsController.php:361](https://github.com/craftcms/cms/blob/c9407c96f077334faacda04f0ae1ad207a01d3e8/src/controllers/EntryRevisionsController.php#L361)), and then it will save it again, this time actually converting the draft to a real entry ([EntryRevisionsController.php:372](https://github.com/craftcms/cms/blob/c9407c96f077334faacda04f0ae1ad207a01d3e8/src/controllers/EntryRevisionsController.php#L372)). This is the time that will signal to Assets fields that it’s safe to start creating new folders based on their dynamic subpath settings, and move the assets over to them from the temp folder.

The bug with Preparse is that it’s currently guarding against ever processing the same entry for the same site twice. So it will update its field values correctly the first time the draft is saved, but not the second time when the draft is being converted to an entry. So if there are any asset URLs in the value, they won’t get updated correctly with the real asset locations.

I’m assuming that the reason Preparse is guarding against processing the same element/site combo more than once is so you avoid nested calls, and if that’s the case then it should be safe to stop worrying about it once it’s done processing. So that’s what this PR does. You might have a better idea of how to fix it though.