### PR TITLE
Add conditional field layouts support to Preparse field type

### DIFF
--- a/src/fields/PreparseFieldType.php
+++ b/src/fields/PreparseFieldType.php
@@ -16,6 +16,9 @@ use craft\base\SortableFieldInterface;
 use craft\db\mysql\Schema;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
+use craft\fields\conditions\DateFieldConditionRule;
+use craft\fields\conditions\NumberFieldConditionRule;
+use craft\fields\conditions\TextFieldConditionRule;
 use craft\gql\types\DateTime as DateTimeType;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
@@ -243,5 +246,25 @@ class PreparseFieldType extends Field implements PreviewableFieldInterface, Sort
             return DateTimeType::getType();
         }
         return parent::getContentGqlType();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getElementConditionRuleType(): array|string|null
+    {
+        switch ($this->columnType) {
+            case Schema::TYPE_DATETIME:
+                return DateFieldConditionRule::class;
+            case Schema::TYPE_DECIMAL;
+            case Schema::TYPE_FLOAT:
+            case Schema::TYPE_INTEGER:
+                return NumberFieldConditionRule::class;
+            case Schema::TYPE_MEDIUMTEXT:
+            case Schema::TYPE_TEXT:
+                return TextFieldConditionRule::class;
+            default:
+            return TextFieldConditionRule::class;
+        }
     }
 }


### PR DESCRIPTION
Recently we were trying to use some of our Preparse field values as conditionals to show and hide other fields in our field layouts but realised this isn't possible at the moment. This PR enables the Preparse field values to be used as part of the conditional field layouts in Craft CMS by adding the `getElementConditionRuleType` function to the `PreparseFieldType` class. 

To account for the different underlying column types that Preparse offers, the function will automatically check for the used column type and return the corresponding, existing field condition rule that Craft CMS already provides. In case this ever gets expanded on, the default `TextFieldConditionRule` will be returned. At the moment it will provide support for `DateFieldConditionRule`, `NumberFieldConditionRule` and `TextFieldConditionRule`.

An example use case (ours in this case) is:
- We have authors that administrate one page via the control panel
- Depending on whether the author has a paid plan, certain fields will be hidden or shown
- We preparse a number value on the page entry by using the user's payment details
- We use the preparsed 1 or 0 value to show or hide specific fields that can only be accessed when you're a paid user

I'd be more than happy to hear and apply any feedback or questions you might have!