### PR TITLE
Propagate changes across sites

### DIFF
--- a/src/PreparseField.php
+++ b/src/PreparseField.php
@@ -130,7 +130,7 @@ class PreparseField extends Plugin
                         }
 
                         $element->setFieldValues($content);
-                        $success = Craft::$app->elements->saveElement($element, true, false);
+                        $success = Craft::$app->elements->saveElement($element, true, true);
 
                         // if no success, log error
                         if (!$success) {


### PR DESCRIPTION
First of all, thanks a lot for your work on this plugin!

I'm using the Preparse field to store a blurhash of images directly to the asset. I noticed, however, that when using multiple sites, the value would only be saved to one site. So when accessing the field in another site, it would be empty — unless the asset was manually re-saved by hand each site.

Switching the propagation behaviur in `saveElement` solves this. I'm not sure, however, if this would lead to unwanted side-effects  in other use cases? For me, this has been working without an obvious issue so far.